### PR TITLE
feat: add zip as an optional dependency

### DIFF
--- a/aws/debian-11/docker.pkr.hcl
+++ b/aws/debian-11/docker.pkr.hcl
@@ -56,6 +56,9 @@ locals {
       "rsync",
       # Needed for bb-clientd
       "fuse",
+      # (Optional) zip is required if any tests create zips of undeclared test outputs
+      # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+      "zip",
       # Additional deps on top of minimal
       "docker.io",
     ]

--- a/aws/debian-11/minimal.pkr.hcl
+++ b/aws/debian-11/minimal.pkr.hcl
@@ -56,6 +56,9 @@ locals {
       "rsync",
       # Needed for bb-clientd
       "fuse",
+      # (Optional) zip is required if any tests create zips of undeclared test outputs
+      # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+      "zip",
     ]
 
     # We'll need to tell systemctl to enable these when the image boots next.

--- a/aws/debian-12/minimal.pkr.hcl
+++ b/aws/debian-12/minimal.pkr.hcl
@@ -58,6 +58,9 @@ locals {
       "mdadm",
       # Needed for bb-clientd
       "fuse",
+      # (Optional) zip is required if any tests create zips of undeclared test outputs
+      # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+      "zip",
     ]
 
     # We'll need to tell systemctl to enable these when the image boots next.

--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -27,6 +27,9 @@ locals {
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
+    # (Optional) zip is required if any tests create zips of undeclared test outputs
+    # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+    "zip",
     # Additional deps on top of minimal
     "docker.io",
   ]

--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -27,6 +27,9 @@ locals {
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
+    # (Optional) zip is required if any tests create zips of undeclared test outputs
+    # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+    "zip",
   ]
 }
 

--- a/gcp/ubuntu-2304-lunar/docker.pkr.hcl
+++ b/gcp/ubuntu-2304-lunar/docker.pkr.hcl
@@ -26,6 +26,9 @@ locals {
   install_packages = [
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
+    # (Optional) zip is required if any tests create zips of undeclared test outputs
+    # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+    "zip",
     # Additional deps on top of minimal
     "docker.io",
   ]

--- a/gcp/ubuntu-2304-lunar/minimal.pkr.hcl
+++ b/gcp/ubuntu-2304-lunar/minimal.pkr.hcl
@@ -26,6 +26,9 @@ locals {
   install_packages = [
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
+    # (Optional) zip is required if any tests create zips of undeclared test outputs
+    # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
+    "zip",
   ]
 }
 


### PR DESCRIPTION
Bazel requires `zip` to zip up undeclared test outputs when they exist. I will test out one of the GCP images first before I create a new set of images and land this.

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
- Manually test on our monorepo.