### PR TITLE
feat: add al2 and al2023 gcc variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ See https://docs.aspect.build/v/workflows/install/packer for accompanying Aspect
 
 These include the minimal dependencies required by Workflows. Not all dependencies are listed in all Packer files, as some distributions base images have these dependencies already installed.
 
+### gcc
+
+This adds gcc & gcc-c++ on top of the minimal Workflows dependencies.
+
 ### docker
 
 This adds docker on top of the minimal Workflows dependencies.

--- a/aws/amazon-linux-2023/gcc.pkr.hcl
+++ b/aws/amazon-linux-2023/gcc.pkr.hcl
@@ -60,6 +60,9 @@ locals {
         "fuse",
         # Install git so we can fetch the source code to be tested, obviously!
         "git",
+        # Additional deps on top of minimal
+        "gcc-c++",
+        "gcc",
     ]
 
     # We'll need to tell systemctl to enable these when the image boots next.
@@ -69,7 +72,7 @@ locals {
 }
 
 source "amazon-ebs" "runner" {
-  ami_name                                  = "aspect-workflows-al2023-minimal-${var.version}"
+  ami_name                                  = "aspect-workflows-al2023-gcc-${var.version}"
   instance_type                             = "t3a.small"
   region                                    = "${var.region}"
   vpc_id                                    = "${var.vpc_id}"


### PR DESCRIPTION
The al2023 gcc variant is required for the rules_ts Aspect Workflows deployment: https://github.com/aspect-build/rules_ts/pull/410

The al2 variant is added here as well so the al2023 gcc variant is not as lonely.

---

### Type of change

- New feature or functionality (change which adds functionality)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

packer build of the new AMIs