### PR TITLE
feat: add GCP ubuntu gcc & docker-gcc-make variant

### DIFF
--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -35,7 +35,7 @@ locals {
 
 source "googlecompute" "image" {
   project_id = "${var.project}"
-  image_family = "aspect-workflows-debian-11"
+  image_family = "aspect-workflows-debian-11-minimal"
   image_name = "aspect-workflows-debian-11-minimal-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"

--- a/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
+++ b/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
@@ -29,13 +29,22 @@ locals {
     # (Optional) zip is required if any tests create zips of undeclared test outputs
     # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
     "zip",
+    # Additional deps on top of minimal
+    "docker.io",
+    "g++",
+    "make",
+  ]
+
+  # We'll need to tell systemctl to start these when the image boots next.
+  enable_services = [
+    "docker.service",
   ]
 }
 
 source "googlecompute" "image" {
   project_id = "${var.project}"
-  image_family = "aspect-workflows-ubuntu-2304"
-  image_name = "aspect-workflows-ubuntu-2304-minimal-${var.version}"
+  image_family = "aspect-workflows-ubuntu-2304-docker-gcc-make"
+  image_name = "aspect-workflows-ubuntu-2304-docker-gcc-make-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "e2-medium"
@@ -64,6 +73,9 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
     ]
   }
 }

--- a/gcp/ubuntu-2304/docker.pkr.hcl
+++ b/gcp/ubuntu-2304/docker.pkr.hcl
@@ -20,12 +20,11 @@ variable "zone" {
 }
 
 locals {
-  source_image = "debian-11-bullseye-v20230629"
+  source_image = "ubuntu-2304-lunar-amd64-v20230613"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
-    "rsync",
-    # fuse will be optional in future release although highly recommended for better performance
+    # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) zip is required if any tests create zips of undeclared test outputs
     # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
@@ -42,8 +41,8 @@ locals {
 
 source "googlecompute" "image" {
   project_id = "${var.project}"
-  image_family = "aspect-workflows-debian-11-docker"
-  image_name = "aspect-workflows-debian-11-docker-${var.version}"
+  image_family = "aspect-workflows-ubuntu-2304-docker"
+  image_name = "aspect-workflows-ubuntu-2304-docker-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "e2-medium"
@@ -58,6 +57,17 @@ build {
   // Install dependencies
   provisioner "shell" {
     inline = [
+      # Disable automated apt updates
+      "sudo systemctl disable apt-daily-upgrade.timer apt-daily.timer",
+
+      # Disable snap refreshes
+      "sudo snap refresh --hold=forever",
+
+      # apt-get update is often running by the time this script begins,
+      # causing a race condition to lock  /var/lib/apt/lists/lock. Kill
+      # any ongoing apt processes to release the lock.
+      "sudo killall apt apt-get || true",
+
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),

--- a/gcp/ubuntu-2304/minimal.pkr.hcl
+++ b/gcp/ubuntu-2304/minimal.pkr.hcl
@@ -29,20 +29,13 @@ locals {
     # (Optional) zip is required if any tests create zips of undeclared test outputs
     # For more information about undecalred test outputs, see https://bazel.build/reference/test-encyclopedia
     "zip",
-    # Additional deps on top of minimal
-    "docker.io",
-  ]
-
-  # We'll need to tell systemctl to start these when the image boots next.
-  enable_services = [
-    "docker.service",
   ]
 }
 
 source "googlecompute" "image" {
   project_id = "${var.project}"
-  image_family = "aspect-workflows-ubuntu"
-  image_name = "aspect-workflows-ubuntu-docker-${var.version}"
+  image_family = "aspect-workflows-ubuntu-2304-minimal"
+  image_name = "aspect-workflows-ubuntu-2304-minimal-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "e2-medium"
@@ -71,9 +64,6 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
-
-      # Enable required services
-      format("sudo systemctl enable %s", join(" ", local.enable_services)),
     ]
   }
 }


### PR DESCRIPTION
rules_js needs the docker + gcc + make variant. Don't really have a good answer for how to prevent a flood of variants for different use cases. I think if a staging repo needs more than docker + gcc + make then we make a kitchen-sink variant at that point.

This PR also cleans up the family names of the GCP images.