### PR TITLE
feat: add GCP Ops utilities to installed packages for images

### DIFF
--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",

--- a/gcp/debian-11/gcc.pkr.hcl
+++ b/gcp/debian-11/gcc.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",

--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",

--- a/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
+++ b/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.

--- a/gcp/ubuntu-2304/docker.pkr.hcl
+++ b/gcp/ubuntu-2304/docker.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.

--- a/gcp/ubuntu-2304/gcc.pkr.hcl
+++ b/gcp/ubuntu-2304/gcc.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.

--- a/gcp/ubuntu-2304/minimal.pkr.hcl
+++ b/gcp/ubuntu-2304/minimal.pkr.hcl
@@ -24,6 +24,9 @@ locals {
 
   # System dependencies required for Aspect Workflows
   install_packages = [
+    # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
+    "google-osconfig-agent",
+    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.


### PR DESCRIPTION
In order to collect vital telemetry from GCP GCE hosts, we need
to install from the command line the utilities responsible, namely
the OS Config agent and the Ops Agent. This adds those packages
to the installed packages list for each image. Other operating
systems with different package managers will need to adopt a
similar syntax.

Ref https://github.com/aspect-build/silo/issues/3224

---

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Suggested release notes are provided below:
Two new dependencies have been added as critical for GCP VM images: OS Config agent and Ops Agent.
Each is vital to receiving proper telemetry for metrics and alarms upstream.

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Deploy image and incorporate into silo deployment for testing.