### PR TITLE
fix: move GCP Ops Agent installation into separate task

### DIFF
--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
@@ -66,6 +65,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),

--- a/gcp/debian-11/gcc.pkr.hcl
+++ b/gcp/debian-11/gcc.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
@@ -61,6 +60,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
     ]
   }
 }

--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
@@ -59,6 +58,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
     ]
   }
 }

--- a/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
+++ b/gcp/ubuntu-2304/docker-gcc-make.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
@@ -78,6 +77,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),

--- a/gcp/ubuntu-2304/docker.pkr.hcl
+++ b/gcp/ubuntu-2304/docker.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
@@ -76,6 +75,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),

--- a/gcp/ubuntu-2304/gcc.pkr.hcl
+++ b/gcp/ubuntu-2304/gcc.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
@@ -71,6 +70,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
     ]
   }
 }

--- a/gcp/ubuntu-2304/minimal.pkr.hcl
+++ b/gcp/ubuntu-2304/minimal.pkr.hcl
@@ -26,7 +26,6 @@ locals {
   install_packages = [
     # Google operational monitoring tools, which are used to collect and alarm on critical telemetry.
     "google-osconfig-agent",
-    "google-cloud-ops-agent",
     # fuse will be optional in future releases although highly recommended for better performance
     "fuse",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
@@ -69,6 +68,10 @@ build {
       # Install dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install Google Cloud Ops Agent
+      "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
+      "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
     ]
   }
 }


### PR DESCRIPTION
The ops agent name is highly dependent on the platform and version,
so move it out of simple install task and into a dedicated install
script invocation.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Published to workflows-images GCP project under version 1.3.0