### PR TITLE
fix: add git to GCP debian 11 images; it is reported that it is missing

### DIFF
--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -29,6 +29,8 @@ locals {
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
+    # Install git so we can fetch the source code to be tested, obviously!
+    "git",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
     "patch",
     # (Optional) zip is required if any tests create zips of undeclared test outputs

--- a/gcp/debian-11/gcc.pkr.hcl
+++ b/gcp/debian-11/gcc.pkr.hcl
@@ -29,6 +29,8 @@ locals {
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
+    # Install git so we can fetch the source code to be tested, obviously!
+    "git",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
     "patch",
     # (Optional) zip is required if any tests create zips of undeclared test outputs

--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -29,6 +29,8 @@ locals {
     "rsync",
     # fuse will be optional in future release although highly recommended for better performance
     "fuse",
+    # Install git so we can fetch the source code to be tested, obviously!
+    "git",
     # (Optional) Patch is required by some rulesets and package managers during dependency fetching.
     "patch",
     # (Optional) zip is required if any tests create zips of undeclared test outputs


### PR DESCRIPTION
Turns out there is no `git` on the GCP debian 11 base image. Some CI hosts require it so we should always include it on our public images.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Build the images and roll them out.