### PR TITLE
chore: set fixed-cidr-ipv6 for GCP Debian 11 docker image

### DIFF
--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -73,6 +73,11 @@ build {
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
+      # We've observed networking issues with Docker on Debian 11 that are resolved by setting
+      # { "ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64" } in the daemon config.
+      "sudo mkdir -p /etc/docker",
+      "echo '{ \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' | sudo tee /etc/docker/daemon.json",
+
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",

--- a/gcp/debian-11/kitchen-sink.pkr.hcl
+++ b/gcp/debian-11/kitchen-sink.pkr.hcl
@@ -75,6 +75,11 @@ build {
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
+      # We've observed networking issues with Docker on Debian 11 that are resolved by setting
+      # { "ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64" } in the daemon config.
+      "sudo mkdir -p /etc/docker",
+      "echo '{ \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' | sudo tee /etc/docker/daemon.json",
+
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",


### PR DESCRIPTION
Built 1-5-1 `gcp/debian-11/docker.pkr.hcl` and `gcp/debian-11/kitchen-sink.pkr.hcl` images