### PR TITLE
feat: create ubuntu 2404 image family

### DIFF
--- a/gcp/ubuntu-2404/docker.pkr.hcl
+++ b/gcp/ubuntu-2404/docker.pkr.hcl
@@ -21,7 +21,7 @@ variable "zone" {
 
 variable "family" {
   type = string
-  default = "aspect-workflows-ubuntu-2304-docker"
+  default = "aspect-workflows-ubuntu-2404-docker"
 }
 
 variable "arch" {
@@ -36,7 +36,7 @@ variable "arch" {
 }
 
 locals {
-  source_image = "ubuntu-2304-lunar-${var.arch}-v20231030"
+  source_image = "ubuntu-2404-noble-${var.arch}-v20240809"
 
   # System dependencies required for Aspect Workflows
   install_packages = [

--- a/gcp/ubuntu-2404/gcc.pkr.hcl
+++ b/gcp/ubuntu-2404/gcc.pkr.hcl
@@ -21,7 +21,7 @@ variable "zone" {
 
 variable "family" {
   type = string
-  default = "aspect-workflows-ubuntu-2304-minimal"
+  default = "aspect-workflows-ubuntu-2404-gcc"
 }
 
 variable "arch" {
@@ -36,7 +36,7 @@ variable "arch" {
 }
 
 locals {
-  source_image = "ubuntu-2304-lunar-${var.arch}-v20231030"
+  source_image = "ubuntu-2404-noble-${var.arch}-v20240809"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
@@ -46,6 +46,8 @@ locals {
     # Optional but recommended dependencies
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "g++",
   ]
 
   machine_types = {

--- a/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -21,7 +21,7 @@ variable "zone" {
 
 variable "family" {
   type = string
-  default = "aspect-workflows-ubuntu-2304-gcc"
+  default = "aspect-workflows-ubuntu-2404-kitchen-sink"
 }
 
 variable "arch" {
@@ -36,7 +36,7 @@ variable "arch" {
 }
 
 locals {
-  source_image = "ubuntu-2304-lunar-${var.arch}-v20231030"
+  source_image = "ubuntu-2404-noble-${var.arch}-v20240809"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
@@ -47,7 +47,14 @@ locals {
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "docker.io",
     "g++",
+    "make",
+  ]
+
+  # We'll need to tell systemctl to start these when the image boots next.
+  enable_services = [
+    "docker.service",
   ]
 
   machine_types = {
@@ -92,6 +99,9 @@ build {
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
     ]
   }
 }

--- a/gcp/ubuntu-2404/minimal.pkr.hcl
+++ b/gcp/ubuntu-2404/minimal.pkr.hcl
@@ -21,7 +21,7 @@ variable "zone" {
 
 variable "family" {
   type = string
-  default = "aspect-workflows-ubuntu-2304-kitchen-sink"
+  default = "aspect-workflows-ubuntu-2404-minimal"
 }
 
 variable "arch" {
@@ -36,7 +36,7 @@ variable "arch" {
 }
 
 locals {
-  source_image = "ubuntu-2304-lunar-${var.arch}-v20231030"
+  source_image = "ubuntu-2404-noble-${var.arch}-v20240809"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
@@ -46,15 +46,6 @@ locals {
     # Optional but recommended dependencies
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-    # Additional deps on top of minimal
-    "docker.io",
-    "g++",
-    "make",
-  ]
-
-  # We'll need to tell systemctl to start these when the image boots next.
-  enable_services = [
-    "docker.service",
   ]
 
   machine_types = {
@@ -99,9 +90,6 @@ build {
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
-
-      # Enable required services
-      format("sudo systemctl enable %s", join(" ", local.enable_services)),
     ]
   }
 }


### PR DESCRIPTION
Use Ubuntu 24.04 for aspect workflows images as a security update for this [CVE](https://ubuntu.com/security/CVE-2023-6931) doesn't appear to get a fix for 23.x.

---

- Manual testing; please provide instructions so we can reproduce:
Already created.