### PR TITLE
feat: add jq to all kitchen sink images where jq exists in the package repositories.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files

--- a/aws/al2023/kitchen-sink.pkr.hcl
+++ b/aws/al2023/kitchen-sink.pkr.hcl
@@ -78,6 +78,7 @@ locals {
         "docker",
         "gcc-c++",
         "gcc",
+        "jq",
         "make",
     ]
 

--- a/aws/debian-11/kitchen-sink.pkr.hcl
+++ b/aws/debian-11/kitchen-sink.pkr.hcl
@@ -79,6 +79,7 @@ locals {
         # Additional deps on top of minimal
         "docker.io",
         "g++",
+        "jq",
         "make",
     ]
 

--- a/aws/debian-12/kitchen-sink.pkr.hcl
+++ b/aws/debian-12/kitchen-sink.pkr.hcl
@@ -81,6 +81,7 @@ locals {
         # Additional deps on top of minimal
         "docker.io",
         "g++",
+        "jq",
         "make",
     ]
 

--- a/aws/ubuntu-2004/kitchen-sink.pkr.hcl
+++ b/aws/ubuntu-2004/kitchen-sink.pkr.hcl
@@ -74,6 +74,7 @@ locals {
         # Additional deps on top of minimal
         "docker.io",
         "g++",
+        "jq",
         "make",
     ]
 

--- a/gcp/debian-11/kitchen-sink.pkr.hcl
+++ b/gcp/debian-11/kitchen-sink.pkr.hcl
@@ -51,6 +51,7 @@ locals {
     # Additional deps on top of minimal
     "docker.io",
     "g++",
+    "jq",
     "make",
   ]
 

--- a/gcp/debian-12/kitchen-sink.pkr.hcl
+++ b/gcp/debian-12/kitchen-sink.pkr.hcl
@@ -51,6 +51,7 @@ locals {
     # Additional deps on top of minimal
     "docker.io",
     "g++",
+    "jq",
     "make",
   ]
 

--- a/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -49,6 +49,7 @@ locals {
     # Additional deps on top of minimal
     "docker.io",
     "g++",
+    "jq",
     "make",
   ]
 


### PR DESCRIPTION
Add jq to all kitchen sink images where jq exists in the package repository.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  JQ installed in kitchen sink images, should be able to run `jq -V`. Be advised
  that Version reporting on Amazon Linux 2023 may be broken due to an upstream
  bug, a workaround was documented in
  https://github.com/amazonlinux/amazon-linux-2023/issues/464