### PR TITLE
chore: add packages to kitchen sink images

### DIFF
--- a/aws/al2/kitchen-sink.pkr.hcl
+++ b/aws/al2/kitchen-sink.pkr.hcl
@@ -64,6 +64,9 @@ locals {
     source_ami = data.amazon-ami.al2.id
 
     # System dependencies required for Aspect Workflows or for build & test
+    # if you have a working docker setup, you can query the packages like so:
+    #   -> % docker run --rm -it --entrypoint bash amazonlinux:2
+    #   bash-4.2# yum search <package>
     install_packages = [
         # Dependencies of Aspect Workflows
         "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
@@ -72,9 +75,13 @@ locals {
         # Optional but recommended dependencies
         "patch",  # patch may be used by some rulesets and package managers during dependency fetching
         # Additional deps on top of minimal
+        "clang",
+        "cmake",
         "docker",
         "gcc-c++",
         "gcc",
+        "jq",
+        "libzstd",
         "make",
     ]
 

--- a/aws/al2023/kitchen-sink.pkr.hcl
+++ b/aws/al2023/kitchen-sink.pkr.hcl
@@ -75,10 +75,13 @@ locals {
         # Optional but recommended dependencies
         "patch",  # patch may be used by some rulesets and package managers during dependency fetching
         # Additional deps on top of minimal
+        "clang",
+        "cmake",
         "docker",
         "gcc-c++",
         "gcc",
         "jq",
+        "libzstd",
         "make",
     ]
 

--- a/aws/debian-11/kitchen-sink.pkr.hcl
+++ b/aws/debian-11/kitchen-sink.pkr.hcl
@@ -79,9 +79,12 @@ locals {
         "patch",  # patch may be used by some rulesets and package managers during dependency fetching
         "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
         # Additional deps on top of minimal
+        "clang",
+        "cmake",
         "docker.io",
         "g++",
         "jq",
+        "libzstd",
         "make",
     ]
 

--- a/aws/ubuntu-2004/kitchen-sink.pkr.hcl
+++ b/aws/ubuntu-2004/kitchen-sink.pkr.hcl
@@ -73,10 +73,14 @@ locals {
         "patch",  # patch may be used by some rulesets and package managers during dependency fetching
         "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
         # Additional deps on top of minimal
+        "clang",
+        "cmake",
         "docker.io",
         "g++",
         "jq",
+        "libzstd",
         "make",
+        "yq",
     ]
 
     # We'll need to tell systemctl to enable these when the image boots next.

--- a/gcp/debian-11/kitchen-sink.pkr.hcl
+++ b/gcp/debian-11/kitchen-sink.pkr.hcl
@@ -49,9 +49,12 @@ locals {
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "clang",
+    "cmake",
     "docker.io",
     "g++",
     "jq",
+    "libzstd",
     "make",
   ]
 

--- a/gcp/debian-12/kitchen-sink.pkr.hcl
+++ b/gcp/debian-12/kitchen-sink.pkr.hcl
@@ -49,10 +49,14 @@ locals {
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "clang",
+    "cmake",
     "docker.io",
     "g++",
     "jq",
+    "libzstd",
     "make",
+    "yq",
   ]
 
   # We'll need to tell systemctl to start these when the image boots next.

--- a/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -47,10 +47,14 @@ locals {
     "patch",  # patch may be used by some rulesets and package managers during dependency fetching
     "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "clang",
+    "cmake",
     "docker.io",
     "g++",
     "jq",
+    "libzstd",
     "make",
+    "yq",
   ]
 
   # We'll need to tell systemctl to start these when the image boots next.


### PR DESCRIPTION
This adds the following packages to our kitchen sink images:
 * clang
 * cmake
 * libzstd
 * yq and jq where they exist in the package repositories.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- Manually tested by booting up docker images and querying the package repositories.
