### PR TITLE
Add git-lfs to all images and the ability to dry run the builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to this repository
+
+## Adding dependencies
+
+### Amazon Linux 2 yum dependencies
+
+If you have a working docker setup, you can query the packages like so:
+
+```
+docker run --rm -it --entrypoint bash amazonlinux:2
+> bash-4.2# yum search <package>
+```

--- a/aws/al2/docker.pkr.hcl
+++ b/aws/al2/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,45 +46,48 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2 Kernel 5.10 AMI <rev> <arch> HVM gp2
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2kernel5dot10.pkr.hcl
 data "amazon-ami" "al2" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2.id
+  source_ami = data.amazon-ami.al2.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        # Additional deps on top of minimal
-        "docker",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    # Recommended dependencies
+    "patch", # patch may be used by some rulesets and package managers during dependency fetching
+    # Additional deps on top of minimal
+    "docker",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -103,12 +106,20 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Install git-lfs on AL2 (https://stackoverflow.com/a/71466001)
+      "sudo amazon-linux-extras install epel -y",
+      "sudo yum-config-manager --enable epel",
+      "sudo yum install --assumeyes git-lfs",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/al2/kitchen-sink.pkr.hcl
+++ b/aws/al2/kitchen-sink.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2-kitchen-sink"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,55 +46,55 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2 Kernel 5.10 AMI <rev> <arch> HVM gp2
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2kernel5dot10.pkr.hcl
 data "amazon-ami" "al2" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2.id
+  source_ami = data.amazon-ami.al2.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    # if you have a working docker setup, you can query the packages like so:
-    #   -> % docker run --rm -it --entrypoint bash amazonlinux:2
-    #   bash-4.2# yum search <package>
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        # Additional deps on top of minimal
-        "clang",
-        "cmake",
-        "docker",
-        "gcc-c++",
-        "gcc",
-        "jq",
-        "libzstd",
-        "make",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    # Recommended dependencies
+    "patch", # patch may be used by some rulesets and package managers during dependency fetching
+    # Additional deps on top of minimal
+    "clang",
+    "cmake",
+    "docker",
+    "gcc-c++",
+    "gcc",
+    "jq",
+    "libzstd",
+    "make",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -113,12 +113,20 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Install git-lfs & yq on AL2 (https://stackoverflow.com/a/71466001)
+      "sudo amazon-linux-extras install epel -y",
+      "sudo yum-config-manager --enable epel",
+      "sudo yum install --assumeyes git-lfs yq",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/al2/minimal.pkr.hcl
+++ b/aws/al2/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,42 +46,45 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2 Kernel 5.10 AMI <rev> <arch> HVM gp2
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2kernel5dot10.pkr.hcl
 data "amazon-ami" "al2" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "amzn2-ami-kernel-5.10-hvm-2.0.20250123.4-${var.arch == "amd64" ? "x86_64" : var.arch}-gp2",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2.id
+  source_ami = data.amazon-ami.al2.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    # Recommended dependencies
+    "patch", # patch may be used by some rulesets and package managers during dependency fetching
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -100,12 +103,20 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Install git-lfs on AL2 (https://stackoverflow.com/a/71466001)
+      "sudo amazon-linux-extras install epel -y",
+      "sudo yum-config-manager --enable epel",
+      "sudo yum install --assumeyes git-lfs",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/al2023/docker.pkr.hcl
+++ b/aws/al2023/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2023-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,48 +46,52 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2023 AMI <rev> <arch> HVM kernel-6.1
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2023.pkr.hcl
 data "amazon-ami" "al2023" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2023.id
+  source_ami = data.amazon-ami.al2023.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "libicu",  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
-        "mdadm",  # required when mounting multiple nvme drives with raid 0
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        # Additional deps on top of minimal
-        "docker",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    "libicu",                  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
+    "mdadm",                   # required when mounting multiple nvme drives with raid 0
+    "rsyslog",                 # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    # Additional deps on top of minimal
+    "docker",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -106,12 +110,15 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/al2023/kitchen-sink.pkr.hcl
+++ b/aws/al2023/kitchen-sink.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2023-kitchen-sink"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,55 +46,60 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2023 AMI <rev> <arch> HVM kernel-6.1
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2023.pkr.hcl
 data "amazon-ami" "al2023" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2023.id
+  source_ami = data.amazon-ami.al2023.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "libicu",  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        # Additional deps on top of minimal
-        "clang",
-        "cmake",
-        "docker",
-        "gcc-c++",
-        "gcc",
-        "jq",
-        "libzstd",
-        "make",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    "libicu",                  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
+    "mdadm",                   # required when mounting multiple nvme drives with raid 0
+    "rsyslog",                 # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    # Additional deps on top of minimal
+    "clang",
+    "cmake",
+    "docker",
+    "gcc-c++",
+    "gcc",
+    "jq",
+    "libzstd",
+    "make",
+    # "yq", TODO: how to install yq on al2023?
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -113,12 +118,15 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/al2023/minimal.pkr.hcl
+++ b/aws/al2023/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-al2023-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,45 +46,49 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want:
 # Amazon Linux 2023 AMI <rev> <arch> HVM kernel-6.1
 # https://github.com/aws/amazon-ecs-ami/blob/main/al2023.pkr.hcl
 data "amazon-ami" "al2023" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
-        root-device-type = "ebs"
-    }
-    owners = ["137112412989"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "al2023-ami-2023.6.20250128.0-kernel-6.1-${var.arch == "amd64" ? "x86_64" : var.arch}",
+    root-device-type    = "ebs"
+  }
+  owners      = ["137112412989"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.al2023.id
+  source_ami = data.amazon-ami.al2023.id
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "amazon-cloudwatch-agent",  # install cloudwatch-agent so that bootstrap logs are easier to locate
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "libicu",  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "amazon-cloudwatch-agent", # install cloudwatch-agent so that bootstrap logs are easier to locate
+    "fuse",                    # required for the Workflows high-performance remote cache configuration
+    "git",                     # required so we can fetch the source code to be tested, obviously!
+    "libicu",                  # libicu is needed by GitHub Actions agent (https://github.com/actions/runner/issues/2511)
+    "mdadm",                   # required when mounting multiple nvme drives with raid 0
+    "rsyslog",                 # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -103,12 +107,15 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-      inline = [
-          # Install dependencies
-          format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
+    inline = [
+      # Install yum dependencies
+      format("sudo yum --setopt=skip_missing_names_on_install=False --assumeyes install %s", join(" ", local.install_packages)),
 
-          # Enable required services
-          format("sudo systemctl enable %s", join(" ", local.enable_services)),
-      ]
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
+    ]
   }
 }

--- a/aws/debian-11/docker.pkr.hcl
+++ b/aws/debian-11/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,53 +46,57 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 11 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-11-${var.arch}-20241202-1949"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-11-${var.arch}-20241202-1949"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "rsync",  # required for bootstrap
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "docker.io",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",  # required for the Workflows high-performance remote cache configuration
+    "git",   # required so we can fetch the source code to be tested, obviously!
+    "rsync", # required for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "docker.io",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -111,19 +115,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-11/gcc.pkr.hcl
+++ b/aws/debian-11/gcc.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-gcc"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,52 +46,56 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 11 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-11-${var.arch}-20241202-1949"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-11-${var.arch}-20241202-1949"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "rsync",  # required for bootstrap
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "g++",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",  # required for the Workflows high-performance remote cache configuration
+    "git",   # required so we can fetch the source code to be tested, obviously!
+    "rsync", # required for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "g++",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -110,19 +114,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-11/kitchen-sink.pkr.hcl
+++ b/aws/debian-11/kitchen-sink.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-kitchen-sink"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,59 +46,64 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 11 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-11-${var.arch}-20241202-1949"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-11-${var.arch}-20241202-1949"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "rsync",  # required for bootstrap
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "clang",
-        "cmake",
-        "docker.io",
-        "g++",
-        "jq",
-        "libzstd1",
-        "make",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",  # required for the Workflows high-performance remote cache configuration
+    "git",   # required so we can fetch the source code to be tested, obviously!
+    "rsync", # required for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "clang",
+    "cmake",
+    "docker.io",
+    "g++",
+    "jq",
+    "libzstd1",
+    "make",
+    "yq",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -117,19 +122,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-11/minimal.pkr.hcl
+++ b/aws/debian-11/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,50 +46,54 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 11 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-11-${var.arch}-20241202-1949"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-11-${var.arch}-20241202-1949"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "rsync",  # required for bootstrap
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",  # required for the Workflows high-performance remote cache configuration
+    "git",   # required so we can fetch the source code to be tested, obviously!
+    "rsync", # required for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -108,19 +112,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-12/docker.pkr.hcl
+++ b/aws/debian-12/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,55 +46,59 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 12 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-12-${var.arch}-20250115-1993"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-12-${var.arch}-20250115-1993"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsync",  # required for bootstrap
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "docker.io",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",    # required for the Workflows high-performance remote cache configuration
+    "git",     # required so we can fetch the source code to be tested, obviously!
+    "mdadm",   # required for mounting multiple nvme drives with raid 0
+    "rsync",   # required for bootstrap
+    "rsyslog", # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "docker.io",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -113,19 +117,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-12/gcc.pkr.hcl
+++ b/aws/debian-12/gcc.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-gcc"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,54 +46,58 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 12 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-12-${var.arch}-20250115-1993"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-12-${var.arch}-20250115-1993"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsync",  # required for bootstrap
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "g++",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",    # required for the Workflows high-performance remote cache configuration
+    "git",     # required so we can fetch the source code to be tested, obviously!
+    "mdadm",   # required for mounting multiple nvme drives with raid 0
+    "rsync",   # required for bootstrap
+    "rsyslog", # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "g++",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -112,19 +116,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-12/kitchen-sink.pkr.hcl
+++ b/aws/debian-12/kitchen-sink.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-kitchen-sink"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,60 +46,66 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 12 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-12-${var.arch}-20250115-1993"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-12-${var.arch}-20250115-1993"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsync",  # required for bootstrap
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "docker.io",
-        "g++",
-        "jq",
-        "make",
-        "libzstd1",
-        "yq",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",    # required for the Workflows high-performance remote cache configuration
+    "git",     # required so we can fetch the source code to be tested, obviously!
+    "mdadm",   # required for mounting multiple nvme drives with raid 0
+    "rsync",   # required for bootstrap
+    "rsyslog", # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "clang",
+    "cmake",
+    "docker.io",
+    "g++",
+    "jq",
+    "libzstd1",
+    "make",
+    "yq",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -118,19 +124,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/debian-12/minimal.pkr.hcl
+++ b/aws/debian-12/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,52 +46,56 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Debian 12 (<rev>)
 data "amazon-ami" "debian" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "debian-12-${var.arch}-20250115-1993"
-        root-device-type = "ebs"
-    }
-    owners = ["136693071363"] # Amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "debian-12-${var.arch}-20250115-1993"
+    root-device-type    = "ebs"
+  }
+  owners      = ["136693071363"] # Amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    source_ami = data.amazon-ami.debian.id
+  source_ami = data.amazon-ami.debian.id
 
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-        # Install system manager so it's easy to login to a machine
-        "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+    # Install system manager so it's easy to login to a machine
+    "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${var.arch}/amazon-ssm-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        "git",  # required so we can fetch the source code to be tested, obviously!
-        "mdadm",  # required for mounting multiple nvme drives with raid 0
-        "rsync",  # required for bootstrap
-        "rsyslog",  # reqired for system logging
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse",    # required for the Workflows high-performance remote cache configuration
+    "git",     # required so we can fetch the source code to be tested, obviously!
+    "mdadm",   # required for mounting multiple nvme drives with raid 0
+    "rsync",   # required for bootstrap
+    "rsyslog", # reqired for system logging
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "amazon-ssm-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "amazon-ssm-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -110,19 +114,24 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2004/docker.pkr.hcl
+++ b/aws/ubuntu-2004/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2004-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,51 +46,54 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 20.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "docker.io",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "docker.io",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -109,23 +112,33 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install git-lfs on Ubuntu 20.04 (https://github.com/git-lfs/git-lfs/issues/4107#issuecomment-624026217)
+      "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash",
+      "sudo apt update",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2004/gcc.pkr.hcl
+++ b/aws/ubuntu-2004/gcc.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2004-gcc"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,50 +46,53 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 20.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "g++",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "g++",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -108,23 +111,33 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install git-lfs on Ubuntu 20.04 (https://github.com/git-lfs/git-lfs/issues/4107#issuecomment-624026217)
+      "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash",
+      "sudo apt update",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2004/minimal.pkr.hcl
+++ b/aws/ubuntu-2004/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2004-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,48 +46,51 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 20.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-${var.arch}-server-20250111"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -106,23 +109,33 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Install git-lfs on Ubuntu 20.04 (https://github.com/git-lfs/git-lfs/issues/4107#issuecomment-624026217)
+      "curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash",
+      "sudo apt update",
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2404/docker.pkr.hcl
+++ b/aws/ubuntu-2404/docker.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-docker"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,51 +46,55 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 24.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "docker.io",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "docker.io",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -109,23 +113,29 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2404/gcc.pkr.hcl
+++ b/aws/ubuntu-2404/gcc.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-gcc"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,50 +46,54 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 24.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "g++",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "g++",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -108,23 +112,29 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/aws/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-kitchen-sink"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,58 +46,62 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 24.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-        # Additional deps on top of minimal
-        "clang",
-        "cmake",
-        "docker.io",
-        "g++",
-        "jq",
-        "libzstd1",
-        "make",
-        "yq",
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    # Additional deps on top of minimal
+    "clang",
+    "cmake",
+    "docker.io",
+    "g++",
+    "jq",
+    "libzstd1",
+    "make",
+    "yq",
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-        "docker.service",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+    "docker.service",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -116,25 +120,29 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-    ],
-    [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/aws/ubuntu-2404/minimal.pkr.hcl
+++ b/aws/ubuntu-2404/minimal.pkr.hcl
@@ -16,28 +16,28 @@ variable "region" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-minimal"
 }
 
 variable "vpc_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "subnet_id" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "encrypt_boot" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -46,48 +46,52 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 # Lookup the base AMI we want
 # Canonical, Ubuntu, 24.04 LTS, <arch> focal image build on <rev>
 data "amazon-ami" "ubuntu" {
-    filters = {
-        virtualization-type = "hvm"
-        name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
-        root-device-type = "ebs"
-    }
-    owners = ["099720109477"] # amazon
-    region = "${var.region}"
-    most_recent = true
+  filters = {
+    virtualization-type = "hvm"
+    name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${var.arch}-server-20250115"
+    root-device-type    = "ebs"
+  }
+  owners      = ["099720109477"] # amazon
+  region      = "${var.region}"
+  most_recent = true
 }
 
 locals {
-    install_debs = [
-        # Install cloudwatch-agent so that bootstrap logs are easier to locale
-        "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
-    ]
+  install_debs = [
+    # Install cloudwatch-agent so that bootstrap logs are easier to locale
+    "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${var.arch}/latest/amazon-cloudwatch-agent.deb",
+  ]
 
-    # System dependencies required for Aspect Workflows or for build & test
-    install_packages = [
-        # Dependencies of Aspect Workflows
-        "fuse",  # required for the Workflows high-performance remote cache configuration
-        # Optional but recommended dependencies
-        "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-        "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
-    ]
+  install_packages = [
+    # Dependencies of Aspect Workflows
+    "fuse", # required for the Workflows high-performance remote cache configuration
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+  ]
 
-    # We'll need to tell systemctl to enable these when the image boots next.
-    enable_services = [
-        "amazon-cloudwatch-agent",
-    ]
+  enable_services = [
+    "amazon-cloudwatch-agent",
+  ]
 
-    instance_types = {
-      amd64 = "t3a.small"
-      arm64 = "c7g.medium"
-    }
+  instance_types = {
+    amd64 = "t3a.small"
+    arm64 = "c7g.medium"
+  }
 
-    awscli_url = {
-      amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    }
+  awscli_url = {
+    amd64 = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    arm64 = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+  }
 }
 
 source "amazon-ebs" "runner" {
@@ -106,23 +110,29 @@ build {
   sources = ["source.amazon-ebs.runner"]
 
   provisioner "shell" {
-    # Install dependencies
     inline = concat([
-        for url in local.install_debs : format("sudo curl %s -O", url)
-    ], [
-        format("sudo dpkg --install --skip-same-version %s", join(" ", [
-          for url in local.install_debs : basename(url)
-        ]))
-    ], [
-        "sudo apt update",
-        format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+      # Fetch debian dependencies
+      for url in local.install_debs : format("sudo curl %s -O", url)
+      ], [
+      # Install debian dependencies
+      format("sudo dpkg --install --skip-same-version %s", join(" ", [
+        for url in local.install_debs : basename(url)
+      ])),
 
-        # Enable required services
-        format("sudo systemctl enable %s", join(" ", local.enable_services)),
-    ], [
+      # Install apt dependencies
+      "sudo apt update",
+      format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
+
+      # Enable required services
+      format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Install AWS CLI
       "curl \"${local.awscli_url[var.arch]}\" -o \"awscliv2.zip\"",
       "unzip awscliv2.zip",
-      "sudo ./aws/install"
+      "sudo ./aws/install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ])
   }
 }

--- a/gcp/debian-11/docker.pkr.hcl
+++ b/gcp/debian-11/docker.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,14 +20,14 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-docker"
 }
 
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -36,19 +36,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-11-bullseye-v20250123"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "docker.io",
   ]
@@ -65,13 +71,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -79,10 +85,9 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
@@ -97,6 +102,9 @@ build {
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-11/gcc.pkr.hcl
+++ b/gcp/debian-11/gcc.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-gcc"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-11-bullseye-v20250123"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "g++",
   ]
@@ -59,13 +65,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -73,16 +79,18 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-11/kitchen-sink.pkr.hcl
+++ b/gcp/debian-11/kitchen-sink.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-kitchen-sink"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-11-bullseye-v20250123"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "clang",
     "cmake",
@@ -56,6 +62,7 @@ locals {
     "jq",
     "libzstd1",
     "make",
+    "yq",
   ]
 
   # We'll need to tell systemctl to start these when the image boots next.
@@ -70,13 +77,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -84,10 +91,9 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
@@ -102,6 +108,9 @@ build {
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-11/minimal.pkr.hcl
+++ b/gcp/debian-11/minimal.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-11-minimal"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-11-bullseye-v20250123"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
   ]
 
   machine_types = {
@@ -57,13 +63,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -71,16 +77,18 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-12/gcc.pkr.hcl
+++ b/gcp/debian-12/gcc.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-gcc"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-12-bookworm-${var.arch == "arm64" ? "arm64-" : ""}v20250113"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "g++",
   ]
@@ -59,13 +65,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -73,16 +79,18 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-12/kitchen-sink.pkr.hcl
+++ b/gcp/debian-12/kitchen-sink.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-kitchen-sink"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-12-bookworm-${var.arch == "arm64" ? "arm64-" : ""}v20250113"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "clang",
     "cmake",
@@ -71,13 +77,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -85,10 +91,9 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
@@ -98,6 +103,9 @@ build {
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/debian-12/minimal.pkr.hcl
+++ b/gcp/debian-12/minimal.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-debian-12-minimal"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,19 +35,25 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "debian-12-bookworm-${var.arch == "arm64" ? "arm64-" : ""}v20250113"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "git",  # required so we can fetch the source code to be tested, obviously!
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    "rsync",  # reqired for bootstrap
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "git",                   # required so we can fetch the source code to be tested, obviously!
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    "rsync",                 # reqired for bootstrap
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
   ]
 
   machine_types = {
@@ -57,13 +63,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -71,16 +77,18 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/ubuntu-2404/docker.pkr.hcl
+++ b/gcp/ubuntu-2404/docker.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-docker"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,17 +35,23 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "ubuntu-2404-noble-${var.arch}-v20250130"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "docker.io",
   ]
@@ -62,13 +68,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -76,7 +82,6 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
       # Disable automated apt updates
@@ -90,7 +95,7 @@ build {
       # any ongoing apt processes to release the lock.
       "sudo killall apt apt-get || true",
 
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
@@ -100,6 +105,9 @@ build {
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/ubuntu-2404/gcc.pkr.hcl
+++ b/gcp/ubuntu-2404/gcc.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-gcc"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,17 +35,23 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "ubuntu-2404-noble-${var.arch}-v20250130"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "g++",
   ]
@@ -57,13 +63,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -71,7 +77,6 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
       # Disable automated apt updates
@@ -85,13 +90,16 @@ build {
       # any ongoing apt processes to release the lock.
       "sudo killall apt apt-get || true",
 
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-kitchen-sink"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,17 +35,23 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "ubuntu-2404-noble-${var.arch}-v20250130"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
     "clang",
     "cmake",
@@ -69,13 +75,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -83,7 +89,6 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
       # Disable automated apt updates
@@ -97,7 +102,7 @@ build {
       # any ongoing apt processes to release the lock.
       "sudo killall apt apt-get || true",
 
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
@@ -107,6 +112,9 @@ build {
 
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }

--- a/gcp/ubuntu-2404/minimal.pkr.hcl
+++ b/gcp/ubuntu-2404/minimal.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     googlecompute = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/googlecompute"
+      source  = "github.com/hashicorp/googlecompute"
     }
   }
 }
@@ -20,13 +20,13 @@ variable "zone" {
 }
 
 variable "family" {
-  type = string
+  type    = string
   default = "aspect-workflows-ubuntu-2404-minimal"
 }
 
 variable "arch" {
-  type = string
-  default = "amd64"
+  type        = string
+  default     = "amd64"
   description = "Target architecture"
 
   validation {
@@ -35,17 +35,23 @@ variable "arch" {
   }
 }
 
+variable "dry_run" {
+  type    = bool
+  default = false
+}
+
 locals {
   source_image = "ubuntu-2404-noble-${var.arch}-v20250130"
 
   # System dependencies required for Aspect Workflows
   install_packages = [
     # Dependencies of Aspect Workflows
-    "fuse",  # required for the Workflows high-performance remote cache configuration
-    "google-osconfig-agent",  # Google operational monitoring tools used to collect and alarm on critical telemetry
-    # Optional but recommended dependencies
-    "patch",  # patch may be used by some rulesets and package managers during dependency fetching
-    "zip",  # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
+    "fuse",                  # required for the Workflows high-performance remote cache configuration
+    "google-osconfig-agent", # Google operational monitoring tools used to collect and alarm on critical telemetry
+    # Recommended dependencies
+    "git-lfs", # support git repositories with LFS
+    "patch",   # patch may be used by some rulesets and package managers during dependency fetching
+    "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
   ]
 
   machine_types = {
@@ -55,13 +61,13 @@ locals {
 }
 
 source "googlecompute" "image" {
-  project_id = "${var.project}"
+  project_id   = "${var.project}"
   image_family = "${var.family}-${var.arch}"
-  image_name = "${var.family}-${var.arch}-${var.version}"
+  image_name   = "${var.family}-${var.arch}-${var.version}"
   source_image = "${local.source_image}"
   ssh_username = "packer"
   machine_type = "${local.machine_types[var.arch]}"
-  zone = "${var.zone}"
+  zone         = "${var.zone}"
 }
 
 build {
@@ -69,7 +75,6 @@ build {
     "source.googlecompute.image",
   ]
 
-  // Install dependencies
   provisioner "shell" {
     inline = [
       # Disable automated apt updates
@@ -83,13 +88,16 @@ build {
       # any ongoing apt processes to release the lock.
       "sudo killall apt apt-get || true",
 
-      # Install dependencies
+      # Install apt dependencies
       "sudo apt-get update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
       # Install Google Cloud Ops Agent
       "curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh",
       "sudo bash add-google-cloud-ops-agent-repo.sh --also-install",
+
+      # Exit with 325 if this is a dry run
+      format("if [ \"%s\" = \"true\" ]; then echo 'DRY RUN COMPLETE for %s-%s'; exit 325; fi", var.dry_run, var.family, var.arch),
     ]
   }
 }


### PR DESCRIPTION
You can now use the `--dry_run` flag to test the packer script without publishing an AMI or image.

Lots of cleanup as well in this PR as well including using `packer fmt` to get consistent formatting.