### PR TITLE
Add Ruby build dependencies to kitchen-sink images

### DIFF
--- a/aws/debian-11/kitchen-sink.pkr.hcl
+++ b/aws/debian-11/kitchen-sink.pkr.hcl
@@ -87,6 +87,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -105,6 +106,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-10-dev",
     "libyaml-dev",
     "libxss1",
@@ -114,6 +116,7 @@ locals {
     "moreutils",
     "xauth",
     "xvfb",
+    "zlib1g-dev",
   ]
 
   enable_services = [

--- a/aws/debian-12/kitchen-sink.pkr.hcl
+++ b/aws/debian-12/kitchen-sink.pkr.hcl
@@ -87,6 +87,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -105,6 +106,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-11-dev",
     "libyaml-dev",
     "libxss1",
@@ -115,6 +117,7 @@ locals {
     "xauth",
     "xvfb",
     "yq",
+    "zlib1g-dev",
   ]
 
   enable_services = [

--- a/aws/debian-13/kitchen-sink.pkr.hcl
+++ b/aws/debian-13/kitchen-sink.pkr.hcl
@@ -88,6 +88,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -106,6 +107,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-14-dev",
     "libyaml-dev",
     "libxss1",
@@ -116,6 +118,7 @@ locals {
     "xauth",
     "xvfb",
     "yq",
+    "zlib1g-dev",
   ]
 
   enable_services = [

--- a/aws/ubuntu-2204/kitchen-sink.pkr.hcl
+++ b/aws/ubuntu-2204/kitchen-sink.pkr.hcl
@@ -78,6 +78,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -97,6 +98,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-11-dev",
     "libxss1",
     "libxtst6",
@@ -108,6 +110,7 @@ locals {
     "xdg-utils",
     "xvfb",
     "yq",
+    "zlib1g-dev",
   ]
 
   enable_services = [

--- a/aws/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/aws/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -78,6 +78,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -98,6 +99,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-11-dev",
     "libxss1",
     "libxtst6",
@@ -110,6 +112,7 @@ locals {
     "xdg-utils",
     "xvfb",
     "yq",
+    "zlib1g-dev",
   ]
 
   enable_services = [

--- a/gcp/debian-11/kitchen-sink.pkr.hcl
+++ b/gcp/debian-11/kitchen-sink.pkr.hcl
@@ -57,6 +57,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -75,6 +76,7 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-10-dev",
     "libyaml-dev",
     "libxss1",
@@ -84,6 +86,7 @@ locals {
     "moreutils",
     "xauth",
     "xvfb",
+    "zlib1g-dev",
   ]
 
   # We'll need to tell systemctl to start these when the image boots next.

--- a/gcp/debian-12/kitchen-sink.pkr.hcl
+++ b/gcp/debian-12/kitchen-sink.pkr.hcl
@@ -57,6 +57,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -75,16 +76,18 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
     "libstdc++-11-dev",
-    "libyaml-dev",
     "libxss1",
     "libxtst6",
+    "libyaml-dev",
     "libzstd1",
     "make",
     "moreutils",
     "xauth",
     "xvfb",
     "yq",
+    "zlib1g-dev",
   ]
 
   # We'll need to tell systemctl to start these when the image boots next.

--- a/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
+++ b/gcp/ubuntu-2404/kitchen-sink.pkr.hcl
@@ -57,6 +57,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "build-essential",
     "clang",
     "cmake",
     "containerd.io",
@@ -75,11 +76,13 @@ locals {
     "libgtk2.0-0",
     "libnotify-dev",
     "libnss3",
+    "libssl-dev",
+    "libzstd1",
     "libstdc++-11-dev",
     "libxss1",
     "libxtst6",
     "libyaml-dev",
-    "libzstd1",
+    "zlib1g-dev",
     "make",
     "moreutils",
     "xauth",


### PR DESCRIPTION
Add zlib1g-dev, build-essential, libssl-dev, and libyaml-dev to all aws and gcp Debian/Ubuntu kitchen-sink images that were missing them.

Appfolio and Carbon both need Ruby support

---

### Changes are visible to end-users: no

### Test plan


- Covered by existing test cases
