### PR TITLE
fix: explicitly add binutils-gold to fix go linker; this was previous…

### DIFF
--- a/aws/debian-13/kitchen-sink.pkr.hcl
+++ b/aws/debian-13/kitchen-sink.pkr.hcl
@@ -88,6 +88,7 @@ locals {
     "patch",   # patch may be used by some rulesets and package managers during dependency fetching
     "zip",     # zip may be used by bazel if there are tests that produce undeclared test outputs which bazel zips; for more information about undeclared test outputs, see https://bazel.build/reference/test-encyclopedia
     # Additional deps on top of minimal
+    "binutils-gold", # needed for external linking with go
     "build-essential",
     "clang",
     "cmake",


### PR DESCRIPTION
…ly part of build-essential in debian 12

### Changes are visible to end-users: yes/no

yes

This adds `binutils-gold` which is required when using `rules_go` with `cgo`. Previously, this package was part of `build-essential` in `debian12` so this keeps parity with that image.