### PR TITLE
chore: add libssl deps

### DIFF
--- a/aws/debian-12/kitchen-sink.pkr.hcl
+++ b/aws/debian-12/kitchen-sink.pkr.hcl
@@ -168,6 +168,11 @@ build {
       "sudo apt update",
       format("sudo apt-get install --assume-yes %s", join(" ", local.install_packages)),
 
+      # Symlink legacy library names that don't exist in Debian 12 but are required by some toolchains.
+      # libssl1.1 was replaced by libssl3; libtinfo5 was replaced by libtinfo6.
+      "MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) && sudo ln -sf /usr/lib/$MULTIARCH/libssl.so.3 /usr/lib/$MULTIARCH/libssl.so.1.1",
+      "MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH) && sudo ln -sf /usr/lib/$MULTIARCH/libtinfo.so.6 /usr/lib/$MULTIARCH/libtinfo.so.5",
+
       # Enable required services
       format("sudo systemctl enable %s", join(" ", local.enable_services)),
 


### PR DESCRIPTION
Hit a case where we need these on the base. Can't be easily installed at runtime due to differences in the releases for each debian build.

---

### Changes are visible to end-users: yes


- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
