### PR TITLE
chore: add libtinfo5 to debian 12 in GCP for Carbon

### DIFF
--- a/gcp/debian-12/kitchen-sink.pkr.hcl
+++ b/gcp/debian-12/kitchen-sink.pkr.hcl
@@ -78,6 +78,7 @@ locals {
     "libnss3",
     "libssl-dev",
     "libstdc++-11-dev",
+    "libtinfo5",
     "libxss1",
     "libxtst6",
     "libyaml-dev",


### PR DESCRIPTION
Trying to keep a fast track on Carbon repo migrations so taking on tech debt for doing things "right". It's going to take significantly longer to build a custom sysroot bundle in their repo to manage deps in a more hermetic way so baking deps in to the AMI should keep us moving for now.

---

### Changes are visible to end-users: no

### Test plan


- Covered by existing test cases
